### PR TITLE
Feature: install Ansible community.docker collection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
 
 # Install Ansible
 RUN pip3 install --no-cache-dir --break-system-packages ansible-core && \
+    ansible-galaxy collection install community.docker && \
     ansible --version
 
 # Install regctl

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Include the image via the **default.image** keyword in your `.gitlab-ci.yml`:
 
 ```yaml
 default:
-  image: ueberdosis/build-tools:0.69.0
+  image: ueberdosis/build-tools:0.70.0
 ```
 
 ## Usage examples
@@ -66,7 +66,7 @@ container_scan:
 To release a new version on Docker Hub run:
 
 ```bash
-export VERSION="0.69.0"
+export VERSION="0.70.0"
 
 # Init buildx
 docker buildx create --use


### PR DESCRIPTION
I'm using this in a pipeline that requires `community.docker.docker_compose_v2` so thought this might be also useful to have in the build tools. 
If you think it's not necessary I can always install `community.docker` directly.

## Changes
- Installs community.docker Ansible collection
- Bumps build-tools version to 0.70